### PR TITLE
Use latest version of scriptlike

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,7 +9,7 @@
 	"targetName": "gen-package-version",
 	"sourcePaths": ["src"],
 	"dependencies": {
-		"scriptlike": "~>0.9.1"
+		"scriptlike": "~>0.10.3"
 	},
 	"preGenerateCommands-posix":
 		["cd $PACKAGE_DIR && rdmd helper/bootstrap.d $SCRIPTLIKE_PACKAGE_DIR"],

--- a/src/genPackageVersion/genDModule.d
+++ b/src/genPackageVersion/genDModule.d
@@ -44,7 +44,7 @@ enum packageTimestampISO = "`~timestampIso~`";
 	//logTrace(dModule);
 	//logTrace("--------------------------------------");
 	
-	import std.path : stdBuildPath = buildPath, stdDirName = dirName;
+	import std.path : stdBuildPath = buildPath, stdDirName = dirName, dirSeparator;
 	import scriptlike.file : scriptlikeRead = read, scriptlikeWrite = write;
 	
 	// Determine output filepath

--- a/src/genPackageVersion/genDdocMacros.d
+++ b/src/genPackageVersion/genDdocMacros.d
@@ -11,6 +11,7 @@ import genPackageVersion.util;
 string generateDdocMacros(string outDir, string packageName, string moduleName,
 	string ver, string timestamp, string timestampIso)
 {
+	import std.path : buildPath;
 	auto macroPrefix = packageName.toUpper().replace(".", "_");
 	
 	// Ensure directory for output file exits

--- a/src/genPackageVersion/getopt.d
+++ b/src/genPackageVersion/getopt.d
@@ -448,7 +448,7 @@ unittest
 
     bool foo;
     bool bar;
-    auto rslt = getopt(args, "foo|f" "Some information about foo.", &foo, "bar|b",
+    auto rslt = getopt(args, "foo|f", "Some information about foo.", &foo, "bar|b",
         "Some help message about bar.", &bar);
 
     if (rslt.helpWanted)
@@ -808,7 +808,7 @@ unittest
     assert(names == ["foo", "bar", "baz"], to!string(names));
 
     names = names.init;
-    args = ["program.name", "-n" "foo,bar,baz"];
+    args = ["program.name", "-n", "foo,bar,baz"];
     getopt(args, "name|n", &names);
     assert(names == ["foo", "bar", "baz"], to!string(names));
 
@@ -1278,7 +1278,7 @@ unittest
     bool foo;
     bool bar;
     auto args = ["prog", "--foo", "-b"];
-    getopt(args, config.caseInsensitive,"foo|f" "Some foo", &foo,
+    getopt(args, config.caseInsensitive,"foo|f", "Some foo", &foo,
         config.caseSensitive, "bar|b", "Some bar", &bar);
     assert(foo);
     assert(bar);
@@ -1289,7 +1289,7 @@ unittest
     bool foo;
     bool bar;
     auto args = ["prog", "-b", "--foo", "-z"];
-    getopt(args, config.caseInsensitive, config.required, "foo|f" "Some foo",
+    getopt(args, config.caseInsensitive, config.required, "foo|f", "Some foo",
         &foo, config.caseSensitive, "bar|b", "Some bar", &bar,
         config.passThrough);
     assert(foo);
@@ -1485,7 +1485,7 @@ unittest
     assert(helpMsg.indexOf("--help") != -1);
     assert(helpMsg.indexOf("Help") != -1);
 
-    string wanted = "Some Text\n-f  --foo Required: Help\n-h --help "
+    string wanted = "Some Text\n-f  --foo Required: Help\n-h --help " ~
         "          This help information.\n";
     assert(wanted == helpMsg, helpMsg ~ wanted);
 }


### PR DESCRIPTION
This is required to build with the latest compiler.

Also fixes some string concatenation issues that weren't really critical in the getopt module, but were obvious mistakes. 2.091.0 complained about the auto concatenation.

Fixes #4.